### PR TITLE
Change entry point of SensoryEvent to #resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,18 @@ In this example, knocking on a door will result in a sensory event targeting sig
 
 #### Resolving Sensory Events
 
-All recipients may not perceive some event the same way. Upon resolution, `SensoryEvent`s therefore need to be contextualized with the point of view of the character experiencing it. This allows taking into account any circumstances of the recipient.
+All recipients may not perceive some event the same way. Upon resolution, `SensoryEvent`s therefore need to be contextualised with the point of view of the character experiencing it. This allows taking into account any circumstances of the recipient.
+
+**Example:**
+
+```javascript
+const event = SensoryEvent.create([
+  { sense: "SIGHT", magnitude: 40, message: "A small imp is hiding in a corner." }
+])
+const character = Character.build({ senses: { "SIGHT": { acuity: 50 } } })
+
+event.resolve(character)
+```
 
 ## Testing
 

--- a/src/SensoryEvent.js
+++ b/src/SensoryEvent.js
@@ -1,14 +1,16 @@
 const _ = require("lodash")
 
 function create(impressions) {
-  return function(character) {
-    _.each(impressions, ({ sense, magnitude, message }) => {
-      const threshold = 100 - character.senses[sense].acuity
+  return {
+    resolve: function(character) {
+      _.each(impressions, ({ sense, magnitude, message }) => {
+        const threshold = 100 - character.senses[sense].acuity
 
-      if(magnitude >= threshold) {
-        return character.send({ sense, message })
-      }
-    })
+        if(magnitude >= threshold) {
+          return character.send({ sense, message })
+        }
+      })
+    }
   }
 }
 

--- a/test/SensoryEventTest.js
+++ b/test/SensoryEventTest.js
@@ -13,7 +13,7 @@ describe("SensoryEvent", function() {
     const character = Character.build({ senses: { "SIGHT": { acuity: 100 } } })
 
     it("forwards the sensory event to the character", function() {
-      event(character)
+      event.resolve(character)
 
       expect(character).to.see("An ogre stands in the middle of the room.")
     })
@@ -26,7 +26,7 @@ describe("SensoryEvent", function() {
     const character = Character.build({ senses: { "SIGHT": { acuity: 40 } } })
 
     it("does not forward the sensory event to the character", function() {
-      event(character)
+      event.resolve(character)
 
       expect(character).to.see.nothing
     })


### PR DESCRIPTION
This change makes `SensoryEvent` invocations read much clearer.

**Before:**

```javascript
event(character)
```

**After:**

```javascript
event.resolve(character)
```