### PR TITLE
 Add simple mechanism for contextualizing sensory messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sludge is a tool for building text based virtual worlds. It is inspired by old w
 
 *Note: This is very much work in progress. Many of the things outlines below are not yet implemented, and are subject to change at a moment's notice.*
 
-Sludge is intended for rapid creation of virtual worlds. It is designed to be fun to use. User productivity is of top priority, and clean mental models and an expressive and intuitive public API are important design objectives. The framework is primarily data driven, with support for sophisticated users to extend it using custom code.
+Sludge is intended for rapid creation of virtual worlds. It is designed to be fun to use. User productivity is a top priority, and clean mental models coupled with an expressive and intuitive public API is an important design objective. The framework is primarily data driven, with support for sophisticated users to extend it using custom code.
 
 ### Topography
 
@@ -16,7 +16,7 @@ To put a spanner in the works of an unfortunate adventurer, exits can be fitted 
 
 ### Command and Conquer
 
-A world would not be very interesting without the ability for characters to act upon it. Whether your inclination is exploring, socialising, or just mindless killing, you need means to express those actions. Sludge uses the concept of `Command`s to achieve this. A command is a high level concept used by world builders to bestow efficacy on the players.
+A world would not be very interesting without the ability for characters to act upon it. Whether you are inclined towards exploring, socialising, or just mindless killing, you need the means to express those actions. Sludge uses the concept of `Command`s to achieve this. A command is a high level construct used by world builders to bestow efficacy on the players.
 
 **Example:**
 
@@ -31,7 +31,7 @@ const Knock = Command.register({
 })
 ```
 
-A command is required to pass a number of `Guard`s before successful. In the case of knocking on a door, shown above, for the knocking to be successful, the actor must be both alive and awake, the direction must be a valid one, and there needs to be an exit in that direction.
+A command is required to pass a number of `Guard`s before succeeding. In the case of knocking on a door, as shown above, for the knocking to be successful, the actor must be both alive and awake, the specified direction must be a cardinal direction, and there needs to be an exit that way.
 
 ### Unified Thing Theory
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ This is made possible through the emission of `SensoryEvent`s. Data packages whi
 
 ```javascript
 const knock = SensoryEvent.create([
-  { sense: "SIGHT", magnitude: 100, message: "${actor} knocks on ${target}" },
-  { sense: "HEARING", magnitude: 70, message: "Someone knocks on ${target}" }
+  { sense: "SIGHT", magnitude: 100, message: ({ actor, target }) => `${actor.name} knocks on ${target}` },
+  { sense: "HEARING", magnitude: 70, message: ({ target }) => `Someone knocks on ${target}` }
 ])
 ```
 

--- a/src/SensoryEvent.js
+++ b/src/SensoryEvent.js
@@ -2,12 +2,12 @@ const _ = require("lodash")
 
 function create(impressions) {
   return {
-    resolve: function(character) {
+    resolve: function(receiver, context = {}) {
       _.each(impressions, ({ sense, magnitude, message }) => {
-        const threshold = 100 - character.senses[sense].acuity
+        const threshold = 100 - receiver.senses[sense].acuity
 
         if(magnitude >= threshold) {
-          return character.send({ sense, message })
+          receiver.perceive({ sense, message: message(context) })
         }
       })
     }

--- a/src/character.js
+++ b/src/character.js
@@ -10,13 +10,16 @@ const DEFAULT_SENSES = {
 
 const Character = Thing.define({
   attributes: {
+    name: "",
     isAlive: true,
     isAwake: true,
     senses: DEFAULT_SENSES,
     impressions: []
   },
   methods: {
-    send: function(event) { this.impressions.push(event) }
+    perceive: function(event) {
+      this.impressions.push(event)
+    }
   }
 })
 

--- a/src/command.js
+++ b/src/command.js
@@ -1,17 +1,19 @@
 const _ = require("lodash")
 
 const DEFAULT_SUCCESS_CALLBACK = function() { return "Yay!" }
-const DEFAULT_FAILURE_CALLBACK = function(actor, message) { actor.send({ sense: "NONE", message }) }
+const DEFAULT_FAILURE_CALLBACK = function(actor, message) { actor.perceive({ sense: "NONE", message }) }
 
 function create({ guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFailure = DEFAULT_FAILURE_CALLBACK }) {
-  return function(actor, parameters) {
-    const results = _.map(guards, (guard) => (guard(actor, parameters)))
-    const failure = _.find(results, (pass) => (pass !== true))
+  return {
+    issue: function(actor, parameters) {
+      const results = _.map(guards, (guard) => (guard(actor, parameters)))
+      const failure = _.find(results, (pass) => (pass !== true))
 
-    if(failure) {
-      return onFailure(actor, failure)
-    } else {
-      return onSuccess()
+      if(failure) {
+        return onFailure(actor, failure)
+      } else {
+        return onSuccess()
+      }
     }
   }
 }

--- a/src/commands/move.js
+++ b/src/commands/move.js
@@ -3,7 +3,11 @@ const Guard = require("../Guard")
 const SensoryEvent = require("../SensoryEvent")
 
 const moveEvent = SensoryEvent.create([
-  { sense: "SIGHT", magnitude: 100, message: `Someone leaves.` }
+  {
+    sense: "SIGHT",
+    magnitude: 100,
+    message: (actor) => `${actor} leaves.`
+  }
 ])
 
 const Move = Command.create({

--- a/test/SensoryEventTest.js
+++ b/test/SensoryEventTest.js
@@ -6,29 +6,43 @@ const SensoryEvent = require("../src/SensoryEvent")
 const Character = require("../src/character")
 
 describe("SensoryEvent", function() {
-  context("when character is powerful enough to experience event", function() {
+  context("when receiver is powerful enough to experience event", function() {
     const event = SensoryEvent.create([
-      { sense: "SIGHT", magnitude: 100, message: "an ogre standing in the middle of the room." }
+      { sense: "SIGHT", magnitude: 100, message: () => "an ogre standing in the middle of the room" }
     ])
-    const character = Character.build({ senses: { "SIGHT": { acuity: 100 } } })
+    const receiver = Character.build({ senses: { "SIGHT": { acuity: 100 } } })
 
-    it("forwards the sensory event to the character", function() {
-      event.resolve(character)
+    it("forwards the sensory event to the receiver", function() {
+      event.resolve(receiver)
 
-      expect(character).to.see("an ogre standing in the middle of the room.")
+      expect(receiver).to.see("an ogre standing in the middle of the room")
     })
   })
 
-  context("when character is not powerful enough to experience event", function() {
+  context("when receiver is not powerful enough to experience event", function() {
     const event = SensoryEvent.create([
-      { sense: "SIGHT", magnitude: 30, message: "an imp cowering in a corner."}
+      { sense: "SIGHT", magnitude: 30, message: () => "an imp cowering in a corner" }
     ])
-    const character = Character.build({ senses: { "SIGHT": { acuity: 40 } } })
+    const receiver = Character.build({ senses: { "SIGHT": { acuity: 40 } } })
 
-    it("does not forward the sensory event to the character", function() {
-      event.resolve(character)
+    it("does not forward the sensory event to the receiver", function() {
+      event.resolve(receiver)
 
-      expect(character).to.see.nothing
+      expect(receiver).to.see.nothing
+    })
+  })
+
+  context("when the event contains contextual information", function() {
+    const event = SensoryEvent.create([
+      { sense: "SIGHT", magnitude: 60, message: ({ actor }) => `${actor.name} prancing around` }
+    ])
+    const actor = Character.build({ name: "Gandalf" })
+    const receiver = Character.build({ senses: { "SIGHT": { acuity: 40 } }})
+
+    it("forwards a contextualized message to the receiver", function() {
+      event.resolve(receiver, { actor })
+
+      expect(receiver).to.see("Gandalf prancing around")
     })
   })
 })

--- a/test/SensoryEventTest.js
+++ b/test/SensoryEventTest.js
@@ -8,20 +8,20 @@ const Character = require("../src/character")
 describe("SensoryEvent", function() {
   context("when character is powerful enough to experience event", function() {
     const event = SensoryEvent.create([
-      { sense: "SIGHT", magnitude: 100, message: "An ogre stands in the middle of the room." }
+      { sense: "SIGHT", magnitude: 100, message: "an ogre standing in the middle of the room." }
     ])
     const character = Character.build({ senses: { "SIGHT": { acuity: 100 } } })
 
     it("forwards the sensory event to the character", function() {
       event.resolve(character)
 
-      expect(character).to.see("An ogre stands in the middle of the room.")
+      expect(character).to.see("an ogre standing in the middle of the room.")
     })
   })
 
   context("when character is not powerful enough to experience event", function() {
     const event = SensoryEvent.create([
-      { sense: "SIGHT", magnitude: 30, message: "An imp cowers in a corner."}
+      { sense: "SIGHT", magnitude: 30, message: "an imp cowering in a corner."}
     ])
     const character = Character.build({ senses: { "SIGHT": { acuity: 40 } } })
 

--- a/test/commands/move.js
+++ b/test/commands/move.js
@@ -11,7 +11,7 @@ describe("MoveCommand", function() {
   context("when the room has an exit in the given direction", function() {
     const room = Room.build({ exits: { north: "foo" } })
     const character = Character.build({ room })
-    const result = MoveCommand(character, { direction: "north" })
+    const result = MoveCommand.issue(character, { direction: "north" })
 
     it("moves the character through the exit", function() {
       expect(result).to.eql("Yay!")
@@ -23,7 +23,7 @@ describe("MoveCommand", function() {
     const character = Character.build({ room })
 
     it("exclaims there is no exit in the given direction", function() {
-      MoveCommand(character, { direction: "south" })
+      MoveCommand.issue(character, { direction: "south" })
 
       expect(character).to.notice("There is no exit south of here.")
     })
@@ -34,7 +34,7 @@ describe("MoveCommand", function() {
     const character = Character.build({ room, isAlive: false })
 
     it("exclaims the character is dead", function() {
-      MoveCommand(character, { direction: "north" })
+      MoveCommand.issue(character, { direction: "north" })
 
       expect(character).to.notice("You are dead ...")
     })
@@ -45,7 +45,7 @@ describe("MoveCommand", function() {
     const character = Character.build({ room, isAwake: false })
 
     it("exclaims the character is not awake", function() {
-      MoveCommand(character, { direction: "north" })
+      MoveCommand.issue(character, { direction: "north" })
 
       expect(character).to.notice("You are asleep ...")
     })


### PR DESCRIPTION
This addition allows contextualizing sensory messages before resolving them. The required context is defined as part of the message like so:

```js
const knock = SensoryEvent.create([
  {
    sense: "SIGHT",
    magnitude: 100,
    message: ({ actor, target }) => `${actor.name} knocks on ${target}`
  }
])
```