### PR TITLE
Add argument handlers

### DIFF
--- a/src/Character.js
+++ b/src/Character.js
@@ -15,7 +15,8 @@ const Character = Thing.define({
     isAlive: true,
     isAwake: true,
     senses: DEFAULT_SENSES,
-    impressions: []
+    impressions: [],
+    inventory: []
   },
   actions: {
     perceive: function(event) {

--- a/src/Finder.js
+++ b/src/Finder.js
@@ -1,0 +1,23 @@
+const _ = require("lodash")
+
+const IRRELEVANT_PARTS = ["a", "an"]
+
+function targetNameMatch(target, name) {
+  const relevantParts = _.reject(_.split(target.name, " "), (part) => _.includes(IRRELEVANT_PARTS, part))
+
+  return _.some(relevantParts, (part) => _.startsWith(_.lowerCase(part), _.lowerCase(name)))
+}
+
+const Finder = {
+  create({ scope, target }) {
+    return {
+      find: function(actor, name) {
+        const candidates = _.filter(actor[scope].contents, (thing) => thing.kindOf(target))
+
+        return _.find(candidates, (candidate) => targetNameMatch(candidate, name))
+      }
+    }
+  }
+}
+
+module.exports = Finder

--- a/src/Finder.js
+++ b/src/Finder.js
@@ -2,10 +2,22 @@ const _ = require("lodash")
 
 const IRRELEVANT_PARTS = ["a", "an"]
 
-function targetNameMatch(target, name) {
+function alludesTo(target, name) {
+  return _.startsWith(_.lowerCase(target), _.lowerCase(name))
+}
+
+function strongMatch(target, name) {
+  return alludesTo(target.name, name)
+}
+
+function weakMatch(target, name) {
   const relevantParts = _.reject(_.split(target.name, " "), (part) => _.includes(IRRELEVANT_PARTS, part))
 
-  return _.some(relevantParts, (part) => _.startsWith(_.lowerCase(part), _.lowerCase(name)))
+  return _.some(relevantParts, (part) => alludesTo(part, name))
+}
+
+function targetNameMatch(target, name) {
+  return strongMatch(target, name) || weakMatch(target, name)
 }
 
 const Finder = {

--- a/src/Room.js
+++ b/src/Room.js
@@ -1,12 +1,13 @@
 const Thing = require("./Thing")
+const Container = require("./traits/container")
 
 const DEFAULT_EXITS = { north: null, east: null, south: null, west: null, up: null, down: null }
 
 const Room = Thing.define({
   attributes: {
-    exits: DEFAULT_EXITS,
-    characters: []
-  }
+    exits: DEFAULT_EXITS
+  },
+  traits: [Container]
 })
 
 module.exports = Room

--- a/src/Thing.js
+++ b/src/Thing.js
@@ -27,7 +27,7 @@ function combineThing(...traits) {
 const ThingFactory = function({ traits, attributes, actions }) {
   const blueprint = combineThing({ attributes, actions }, THING_TRAIT, ...traits)
 
-  const kindOf = (trait) => _.some(traits, { name: trait })
+  const kindOf = (trait) => _.some([THING_TRAIT, ...traits], { name: trait })
 
   const blueprintMethods = {
     attributes,

--- a/src/Thing.js
+++ b/src/Thing.js
@@ -1,5 +1,13 @@
 const _ = require("lodash")
 
+const THING_TRAIT = {
+  name: "thing",
+  attributes: {
+    name: "",
+    description: ""
+  }
+}
+
 function assignAttributes(attributes, options) {
   const unknownAttributes = _.difference(_.keys(options), _.keys(attributes))
 
@@ -10,14 +18,14 @@ function assignAttributes(attributes, options) {
   }
 }
 
-function combineThing(traits) {
+function combineThing(...traits) {
   return _.reduce(traits, function(thing, trait) {
     return _.merge(thing, _.cloneDeep(trait))
   })
 }
 
 const ThingFactory = function({ traits, attributes, actions }) {
-  const blueprint = combineThing(_.concat({ attributes, actions }, traits))
+  const blueprint = combineThing({ attributes, actions }, THING_TRAIT, ...traits)
 
   const kindOf = (trait) => _.some(traits, { name: trait })
 

--- a/src/commands/look.js
+++ b/src/commands/look.js
@@ -1,0 +1,17 @@
+const Command = require("../Command")
+const Finder = require("../Finder")
+const Guard = require("../Guard")
+
+const finder = Finder.create({ scope: "room", target: "thing" })
+
+const Move = Command.create({
+  arguments: [
+    { tag: "target", finder }
+  ],
+  guards: [
+    Guard.actorMustBeAlive,
+    Guard.actorMustBeAwake
+  ]
+})
+
+module.exports = Move

--- a/src/traits/equippable.js
+++ b/src/traits/equippable.js
@@ -1,0 +1,11 @@
+const Equippable = {
+  name: "equippable",
+  attributes: {
+    slot: ""
+  },
+  actions: {
+    // TODO: implement
+  }
+}
+
+module.exports = Equippable

--- a/test/FinderTest.js
+++ b/test/FinderTest.js
@@ -15,6 +15,12 @@ describe("Finder", function() {
       const room = Room.build({ contents: [bag] })
       const character = Character.build({ room: room })
 
+      context("when matching the entire name", function() {
+        it("finds the bag", function() {
+          expect(finder.find(character, "magic pouch")).to.eq(bag)
+        })
+      })
+
       context("when matching the entire first part of the name", function() {
         it("finds the bag", function() {
           expect(finder.find(character, "magic")).to.eq(bag)

--- a/test/FinderTest.js
+++ b/test/FinderTest.js
@@ -1,0 +1,55 @@
+const { expect } = require("chai")
+
+const Finder = require("../src/Finder")
+
+const Character = require("../src/Character")
+const Room = require("../src/Room")
+const Bag = require("../src/Bag")
+
+describe("Finder", function() {
+  describe("#find", function() {
+    const finder = Finder.create({ scope: "room", target: "container" })
+    const bag = Bag.build({ name: "Magic Pouch" })
+
+    context("when a matching bag exists in scope", function(){
+      const room = Room.build({ contents: [bag] })
+      const character = Character.build({ room: room })
+
+      context("when matching the entire first part of the name", function() {
+        it("finds the bag", function() {
+          expect(finder.find(character, "magic")).to.eq(bag)
+        })
+      })
+
+      context("when matching the entire last part of the name", function() {
+        it("finds the bag", function() {
+          expect(finder.find(character, "pouch")).to.eq(bag)
+        })
+      })
+
+      context("when matching a subset of the first part of the name", function() {
+        it("finds the bag", function() {
+          expect(finder.find(character, "pou")).to.eq(bag)
+        })
+      })
+    })
+
+    context("when a non-matching bag exists in scope", function(){
+      const room = Room.build({ contents: [bag] })
+      const character = Character.build({ room: room })
+
+      it("does not find the bag", function() {
+        expect(finder.find(character, "ordinary")).to.be.undefined
+      })
+    })
+
+    context("when a matching bag exists in another scope", function() {
+      const room = Room.build({ contents: [] })
+      const character = Character.build({ room: room, inventory: [bag] })
+
+      it("does not find the bag", function() {
+        expect(finder.find(character, "magic")).to.be.undefined
+      })
+    })
+  })
+})

--- a/test/ThingTest.js
+++ b/test/ThingTest.js
@@ -2,14 +2,15 @@ const { expect } = require("chai")
 
 const Thing = require("../src/Thing")
 const Container = require("../src/traits/container")
+const Equippable = require("../src/traits/equippable")
 
 describe("Thing", function() {
   describe("#attributes", function() {
     context("when defined without attributes", function() {
       const thing = Thing.define({})
 
-      it("does not list any attributes", function() {
-        expect(thing.attributes).to.be.empty
+      it("lists the default attributes", function() {
+        expect(thing.attributes).to.contain.keys("name", "description")
       })
     })
 
@@ -21,11 +22,27 @@ describe("Thing", function() {
       })
     })
 
-    context("when inheriting attributes from traits", function() {
+    context("when inheriting attributes from a single trait", function() {
       const thing = Thing.define({ traits: [Container] })
 
       it("lists the names of the inherited attributes", function() {
         expect(thing.attributes).to.contain.key("contents")
+      })
+    })
+
+    context("when inheriting attributes from several traits", function() {
+      const thing = Thing.define({ traits: [Container, Equippable] })
+
+      it("lists the names of the inherited attributes", function() {
+        expect(thing.attributes).to.contain.keys("contents", "slot")
+      })
+    })
+
+    context("when defined with- and inheriting attributes from a trait", function() {
+      const thing = Thing.define({ attributes: { name: "a bag" }, traits: [Container] })
+
+      it("lists both the defined and inherited attributes", function() {
+        expect(thing.attributes).to.contain.keys("name", "contents")
       })
     })
   })
@@ -39,11 +56,19 @@ describe("Thing", function() {
       })
     })
 
-    context("when defined with traits", function() {
+    context("when defined with a single trait", function() {
       const thing = Thing.define({ traits: [Container] })
 
-      it("lists the names of its traits", function() {
+      it("lists the trait", function() {
         expect(thing.traits).to.deep.include(Container)
+      })
+    })
+
+    context("when defined with several traits", function() {
+      const thing = Thing.define({ traits: [Container, Equippable] })
+
+      it("lists all the traits", function() {
+        expect(thing.traits).to.deep.include(Container, Equippable)
       })
     })
   })
@@ -58,7 +83,7 @@ describe("Thing", function() {
     })
 
     context("when argument does not match any of the traits", function() {
-      const thing = Thing.define({ traits: [] })
+      const thing = Thing.define({ traits: [Equippable] })
 
       it("returns false", function() {
         expect(thing.kindOf("container")).to.be.false

--- a/test/ThingTest.js
+++ b/test/ThingTest.js
@@ -1,3 +1,5 @@
+require("./support/helpers")
+
 const { expect } = require("chai")
 
 const Thing = require("../src/Thing")
@@ -74,11 +76,19 @@ describe("Thing", function() {
   })
 
   describe("#kindOf", function() {
+    context("when argument is thing", function() {
+      const thing = Thing.define({})
+
+      it("returns true", function() {
+        expect(thing).to.be.a.kindOf("thing")
+      })
+    })
+
     context("when argument matches one of the traits", function() {
       const thing = Thing.define({ traits: [Container] })
 
       it("returns true", function() {
-        expect(thing.kindOf("container")).to.be.true
+        expect(thing).to.be.a.kindOf("container")
       })
     })
 
@@ -86,15 +96,15 @@ describe("Thing", function() {
       const thing = Thing.define({ traits: [Equippable] })
 
       it("returns false", function() {
-        expect(thing.kindOf("container")).to.be.false
+        expect(thing).not.to.be.a.kindOf("container")
       })
     })
 
-    context("when called on an instance of the factory", function() {
-      const thing = Thing.define({ traits: [Container] })
+    context("when called on an instance of the thing", function() {
+      const thing = Thing.define({ traits: [Container] }).build()
 
       it("returns true", function() {
-        expect(thing.build().kindOf("container")).to.be.true
+        expect(thing).to.be.a.kindOf("container")
       })
     })
   })

--- a/test/ThingTest.js
+++ b/test/ThingTest.js
@@ -89,5 +89,13 @@ describe("Thing", function() {
         expect(thing.kindOf("container")).to.be.false
       })
     })
+
+    context("when called on an instance of the factory", function() {
+      const thing = Thing.define({ traits: [Container] })
+
+      it("returns true", function() {
+        expect(thing.build().kindOf("container")).to.be.true
+      })
+    })
   })
 })

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -66,3 +66,11 @@ Assertion.addProperty("something", function() {
     `expected character to not ${presentTenseVerb} something`
   )
 })
+
+Assertion.addMethod('kindOf', function (trait) {
+  this.assert(
+    this._obj.kindOf(trait) === true,
+    `expected thing to be a kind of ${trait}`,
+    `expected thing to not be a kind of ${trait}`
+  )
+})


### PR DESCRIPTION
This change adds a `Finder` factory, which allows creating handlers for command arguments. The factory takes in a scope and a target trait, and creates a finder that, when parameterized with the actor
and a name string, searches for a matching target from the perspective of the actor.

Example:

```
const containersInRoom = Finder.create({ scope: "room", target: "container" })
```