### PR TITLE
Have finders support multiple scopes and targets

### DIFF
--- a/src/Finder.js
+++ b/src/Finder.js
@@ -20,11 +20,19 @@ function targetNameMatch(target, name) {
   return strongMatch(target, name) || weakMatch(target, name)
 }
 
+function filterCandidates(actor, scopes, targets) {
+  return _.flatMap(scopes, (scope) => {
+    return _.filter(actor[scope].contents, (thing) => {
+      return _.some(targets, (target) => thing.kindOf(target))
+    })
+  })
+}
+
 const Finder = {
-  create({ scope, target }) {
+  create({ scopes, targets }) {
     return {
       find: function(actor, name) {
-        const candidates = _.filter(actor[scope].contents, (thing) => thing.kindOf(target))
+        const candidates = filterCandidates(actor, scopes, targets)
 
         return _.find(candidates, (candidate) => targetNameMatch(candidate, name))
       }

--- a/test/FinderTest.js
+++ b/test/FinderTest.js
@@ -8,52 +8,52 @@ const Bag = require("../src/Bag")
 
 describe("Finder", function() {
   describe("#find", function() {
-    const finder = Finder.create({ scope: "room", target: "container" })
-    const bag = Bag.build({ name: "Magic Pouch" })
+    const finder = Finder.create({ scopes: ["room"], targets: ["container"] })
+    const pouch = Bag.build({ name: "Magic Pouch" })
 
-    context("when a matching bag exists in scope", function(){
-      const room = Room.build({ contents: [bag] })
+    context("when a matching pouch exists in scope", function() {
+      const room = Room.build({ contents: [pouch] })
       const character = Character.build({ room: room })
 
       context("when matching the entire name", function() {
-        it("finds the bag", function() {
-          expect(finder.find(character, "magic pouch")).to.eq(bag)
+        it("finds the pouch", function() {
+          expect(finder.find(character, "magic pouch")).to.eq(pouch)
         })
       })
 
       context("when matching the entire first part of the name", function() {
-        it("finds the bag", function() {
-          expect(finder.find(character, "magic")).to.eq(bag)
+        it("finds the pouch", function() {
+          expect(finder.find(character, "magic")).to.eq(pouch)
         })
       })
 
       context("when matching the entire last part of the name", function() {
-        it("finds the bag", function() {
-          expect(finder.find(character, "pouch")).to.eq(bag)
+        it("finds the pouch", function() {
+          expect(finder.find(character, "pouch")).to.eq(pouch)
         })
       })
 
       context("when matching a subset of the first part of the name", function() {
-        it("finds the bag", function() {
-          expect(finder.find(character, "pou")).to.eq(bag)
+        it("finds the pouch", function() {
+          expect(finder.find(character, "pou")).to.eq(pouch)
         })
       })
     })
 
-    context("when a non-matching bag exists in scope", function(){
-      const room = Room.build({ contents: [bag] })
+    context("when a non-matching pouch exists in scope", function(){
+      const room = Room.build({ contents: [pouch] })
       const character = Character.build({ room: room })
 
-      it("does not find the bag", function() {
+      it("does not find the pouch", function() {
         expect(finder.find(character, "ordinary")).to.be.undefined
       })
     })
 
-    context("when a matching bag exists in another scope", function() {
+    context("when a matching pouch exists in another scope", function() {
       const room = Room.build({ contents: [] })
-      const character = Character.build({ room: room, inventory: [bag] })
+      const character = Character.build({ room: room, inventory: [pouch] })
 
-      it("does not find the bag", function() {
+      it("does not find the pouch", function() {
         expect(finder.find(character, "magic")).to.be.undefined
       })
     })


### PR DESCRIPTION
This change allows finders to look in multiple scopes for several target traits. These will be searched in the order they are listed.

**Before:**

```js
Finder.create({ scope: "room", target: "container" })
```

**After:**

```js
Finder.create({ scopes: ["room"], targets: ["container"] })
```