### PR TITLE
Add documentation comment to Thing

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -3,8 +3,22 @@ const _ = require("lodash")
 const DEFAULT_SUCCESS_CALLBACK = function() { return "Yay!" }
 const DEFAULT_FAILURE_CALLBACK = function(actor, message) { actor.perceive({ sense: "NONE", message }) }
 
-function create({ guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFailure = DEFAULT_FAILURE_CALLBACK }) {
+/*
+ * Command registry. This holds a reference to all the registered commands
+ * in memory.
+ */
+let commands = []
+
+/**
+ * Creates a new command.
+ */
+function create({ name, guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFailure = DEFAULT_FAILURE_CALLBACK }) {
+  if(_.isEmpty(name)) {
+    throw new Error(`Command created without a name`)
+  }
+
   return {
+    name,
     issue: function(actor, parameters) {
       const results = _.map(guards, (guard) => (guard(actor, parameters)))
       const failure = _.find(results, (pass) => (pass !== true))
@@ -18,8 +32,66 @@ function create({ guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFailure =
   }
 }
 
+/**
+ * Registers a command by creating it and adding it to the command registry.
+ * Does some checks to avoid name clashes.
+ */
+function register({ name, guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFailure = DEFAULT_FAILURE_CALLBACK }) {
+  const command = create({ name, guards, onSuccess, onFailure })
+
+  if(_.some(commands, { name })) {
+    throw new Error(`Command already registered: ${name}`)
+  } else {
+    commands.push(command)
+  }
+}
+
+/**
+ * Checks whether a passed string seems to allude to a known target string.
+ */
+function isAlludingTo(target, name) {
+  return _.startsWith(_.lowerCase(target), _.lowerCase(name))
+}
+
+/**
+ * The unknown command is a null command used when a matching command can't
+ * be found. It always succeeds, and gives the player an indication that a
+ * command wasn't found. It is treated as a regular command, and pushed to
+ * the character's command queue.
+ */
+const UnknownCommand = {
+  name: "unknown",
+  issue: function(actor) {
+    actor.perceive({ sense: "NONE", message: "Huh?" })
+  }
+}
+
+/**
+ * Takes in a string and attempts to find a matching command from the
+ * command registry. Returns the unknown command if it can't find a match.
+ */
+function parse(string) {
+  return _.find(commands, function(command) {
+    return isAlludingTo(command.name, string)
+  }) || UnknownCommand
+}
+
+/**
+ * Danger zone! Clear all commands in the command registry. This is useful
+ * in a lot of tests.
+ */
+function clear() {
+  commands = []
+}
+
+/**
+ * Public API for `Command`.
+ */
 const Command = {
-  create
+  clear,
+  create,
+  register,
+  parse
 }
 
 module.exports = Command

--- a/src/Thing.js
+++ b/src/Thing.js
@@ -1,29 +1,47 @@
 const _ = require("lodash")
 
+/**
+ * Bottom level trait that is used for all things. Adds basic attributes and
+ * allows finders to target `thing`.
+ */
 const THING_TRAIT = {
   name: "thing",
   attributes: {
+    id: "",
     name: "",
     description: ""
   }
 }
 
+/**
+ * Assign attributes to an instance of `Thing`. Does some basic checks to
+ * prevent assigning undefined attributes.
+ */
 function assignAttributes(attributes, options) {
   const unknownAttributes = _.difference(_.keys(options), _.keys(attributes))
+  const defaultAttributes = { id: _.uniqueId() }
 
   if(_.isEmpty(unknownAttributes)) {
-    return _.merge(_.cloneDeep(attributes), options)
+    return _.merge(_.cloneDeep(attributes), defaultAttributes, options)
   } else {
     throw(`Unknown attributes: ${_.join(unknownAttributes, ", ")}`)
   }
 }
 
+/**
+ * Combines any number of traits into a new blueprint.
+ */
 function combineThing(...traits) {
   return _.reduce(traits, function(thing, trait) {
     return _.merge(thing, _.cloneDeep(trait))
   })
 }
 
+/**
+ * Each definition of a new `Thing` generates a new factory, capable of
+ * creating instances of that `Thing`, as well as holding some information
+ * about the traits and attributes used on definition.
+ */
 const ThingFactory = function({ traits, attributes, actions }) {
   const blueprint = combineThing({ attributes, actions }, THING_TRAIT, ...traits)
 
@@ -42,6 +60,9 @@ const ThingFactory = function({ traits, attributes, actions }) {
   return _.merge({ build }, blueprintMethods)
 }
 
+/**
+ * Public API for `Thing`.
+ */
 const Thing = {
   define({ traits = [], attributes = {}, actions = {} }) {
     return ThingFactory({ traits, attributes, actions })

--- a/src/commands/look.js
+++ b/src/commands/look.js
@@ -5,6 +5,7 @@ const Guard = require("../Guard")
 const finder = Finder.create({ scope: "room", target: "thing" })
 
 const Move = Command.create({
+  name: "look",
   arguments: [
     { tag: "target", finder }
   ],

--- a/src/commands/move.js
+++ b/src/commands/move.js
@@ -1,4 +1,5 @@
 const Command = require("../Command")
+const Finder = require("../Finder")
 const Guard = require("../Guard")
 const SensoryEvent = require("../SensoryEvent")
 
@@ -6,11 +7,17 @@ const moveEvent = SensoryEvent.create([
   {
     sense: "SIGHT",
     magnitude: 100,
-    message: (actor) => `${actor} leaves.`
+    message: (actor, direction) => `${actor} leaves ${direction}.`
   }
 ])
 
+const finder = Finder.create({ scope: "room", target: "exit" })
+
 const Move = Command.create({
+  name: "move",
+  arguments: [
+    { tag: "exit", finder }
+  ],
   guards: [
     Guard.actorMustBeAlive,
     Guard.actorMustBeAwake,

--- a/test/CommandTest.js
+++ b/test/CommandTest.js
@@ -1,0 +1,79 @@
+const { expect } = require("chai")
+
+const Command = require("../src/Command")
+
+describe("Command", function() {
+  describe(".create", function() {
+    context("when creating without a name", function() {
+      const creation = function() {
+        Command.create({ name: "" })
+      }
+
+      it("raises an error", function() {
+        expect(creation).to.throw("Command created without a name")
+      })
+    })
+
+    context("when creating with a name", function() {
+      const creation = function() {
+        Command.create({ name: "foo" })
+      }
+
+      it("does not raise an error", function() {
+        expect(creation).not.to.throw
+      })
+    })
+  })
+
+  describe(".register", function() {
+    afterEach("clear command registry", function() {
+      Command.clear()
+    })
+
+    context("when registering a new command", function() {
+      const registration = function() {
+        Command.register({ name: "foo" })
+      }
+
+      it("does not raise an error", function() {
+        expect(registration).not.to.throw
+      })
+    })
+
+    context("when registerig a command whose name is already taken", function() {
+      before(function() {
+        Command.register({ name: "bar" })
+      })
+
+      const registration = function() {
+        Command.register({ name: "bar" })
+      }
+
+      it("raises an error", function() {
+        expect(registration).to.throw("Command already registered: bar")
+      })
+    })
+  })
+
+  describe(".parse", function() {
+    afterEach("clear command registry", function() {
+      Command.clear()
+    })
+
+    context("when a matching command exists", function() {
+      before(function() {
+        Command.register({ name: "foo" })
+      })
+
+      it("returns the command", function() {
+        expect(Command.parse("foo").name).to.eq("foo")
+      })
+    })
+
+    context("when no matching command exists", function() {
+      it("returns the unknown command", function() {
+        expect(Command.parse("bar").name).to.eq("unknown")
+      })
+    })
+  })
+})


### PR DESCRIPTION
This change adds basic command parsing through `Command.parse`. It will eventually take the first fragment of a user string, e.g.:

> **move** north

and try to find a matching command in the command registry. If it can't find one, it will return the `UnknownCommand` instead.

(Handlers for the remaining fragments are defined upon registering the command.)

New commands can be added to the registry through `Command.register`.