### PR TITLE
Add simple connectors

### DIFF
--- a/src/Connector.js
+++ b/src/Connector.js
@@ -1,0 +1,22 @@
+const _ = require("lodash")
+
+const Thing = require("./Thing")
+
+const Connector = Thing.define({
+  attributes: {
+    exits: []
+  },
+  actions: {
+    connect: function(exits) {
+      this.exits = _.concat(this.exits, exits)
+      _.each(exits, function(exit) {
+        exit.connector = this
+      })
+    },
+    resolve: function(source) {
+      return _.first(_.reject(this.exits, source))
+    }
+  }
+})
+
+module.exports = Connector

--- a/src/Finder.js
+++ b/src/Finder.js
@@ -1,25 +1,48 @@
 const _ = require("lodash")
 
+/**
+ * String fragments that are ignored in weak matching of target strings.
+ */
 const IRRELEVANT_PARTS = ["a", "an"]
 
-function alludesTo(target, name) {
+/**
+ * Checks whether a passed string seems to allude to a known target string.
+ */
+function isAlludingTo(target, name) {
   return _.startsWith(_.lowerCase(target), _.lowerCase(name))
 }
 
-function strongMatch(target, name) {
-  return alludesTo(target.name, name)
+/**
+ * A strong match indicates that that the passed string alludes to a known
+ * target string _including_ irrelevant parts like prefixes.
+ */
+function isStrongMatch(target, name) {
+  return isAlludingTo(target.name, name)
 }
 
-function weakMatch(target, name) {
+/**
+ * A weak match indicates that the passed string alludes to a known targets
+ * string when ignoring irrelevant parts like prefixes.
+ */
+function isWeakMatch(target, name) {
   const relevantParts = _.reject(_.split(target.name, " "), (part) => _.includes(IRRELEVANT_PARTS, part))
 
-  return _.some(relevantParts, (part) => alludesTo(part, name))
+  return _.some(relevantParts, (part) => isAlludingTo(part, name))
 }
 
-function targetNameMatch(target, name) {
-  return strongMatch(target, name) || weakMatch(target, name)
+/**
+ * Either a strong or a weak match.
+ */
+function isMatch(target, name) {
+  return isStrongMatch(target, name) || isWeakMatch(target, name)
 }
 
+/**
+ * A two pass filter that looks for candidate targets by:
+ *
+ *   1. Filtering things that are in the indicated scope(s)
+ *   2. Filtering things that match the indicated target(s)
+ */
 function filterCandidates(actor, scopes, targets) {
   return _.flatMap(scopes, (scope) => {
     return _.filter(actor[scope].contents, (thing) => {
@@ -28,13 +51,20 @@ function filterCandidates(actor, scopes, targets) {
   })
 }
 
+/**
+ * A `Finder` is an object that attempts to find target `Thing`s that
+ * are alluded to in arguments to commands. For example, the commands
+ * "look stick" attempts to find a suitable stick to look at in the
+ * relevant scopes. Which scopes are relevant is decided by the command
+ * when it is created.
+ */
 const Finder = {
   create({ scopes, targets }) {
     return {
       find: function(actor, name) {
         const candidates = filterCandidates(actor, scopes, targets)
 
-        return _.find(candidates, (candidate) => targetNameMatch(candidate, name))
+        return _.find(candidates, (candidate) => isMatch(candidate, name))
       }
     }
   }

--- a/src/SensoryEvent.js
+++ b/src/SensoryEvent.js
@@ -1,5 +1,10 @@
 const _ = require("lodash")
 
+/**
+ * Creates a new `SensoryEvent` to be perceived by actors. It takes a list of
+ * impressions, one per targeted sense, which are resolved in order of priority
+ * of the receiver.
+ */
 function create(impressions) {
   return {
     resolve: function(receiver, context = {}) {
@@ -14,6 +19,9 @@ function create(impressions) {
   }
 }
 
+/**
+ * Public API for `SensoryEvent`.
+ */
 const SensoryEvent = {
   create
 }

--- a/test/ConnectorTest.js
+++ b/test/ConnectorTest.js
@@ -1,0 +1,21 @@
+const { expect } = require("chai")
+
+const Exit = require("../src/Exit")
+const Connector = require("../src/Connector")
+
+describe("Connector", function() {
+  describe("#resolve", function() {
+    context("when using the default duplex resolver", function() {
+      const source = Exit.build({})
+      const destination = Exit.build({})
+
+      const connector = Connector.build({})
+
+      it("returns the opposite exit", function() {
+        connector.connect([source, destination])
+
+        expect(connector.resolve(source)).to.eq(destination)
+      })
+    })
+  })
+})

--- a/test/ThingTest.js
+++ b/test/ThingTest.js
@@ -12,7 +12,7 @@ describe("Thing", function() {
       const thing = Thing.define({})
 
       it("lists the default attributes", function() {
-        expect(thing.attributes).to.contain.keys("name", "description")
+        expect(thing.attributes).to.contain.keys("id", "name", "description")
       })
     })
 


### PR DESCRIPTION
This change adds a simple (duplex) connector. It connects two exits, source and destination.

```
Room <-> Exit <-> Connector <-> Exit <-> Room
```

The idea is that you can have any type of connector that you want. Perhaps an impasse connector which brings you back through the same exit, a one-way connector, or a maze connector.