### PR TITLE
Add basic yawn command

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -26,7 +26,7 @@ function create({ name, guards = [], onSuccess = DEFAULT_SUCCESS_CALLBACK, onFai
       if(failure) {
         return onFailure(actor, failure)
       } else {
-        return onSuccess()
+        return onSuccess({ actor })
       }
     }
   }

--- a/src/Room.js
+++ b/src/Room.js
@@ -1,3 +1,5 @@
+const _ = require("lodash")
+
 const Thing = require("./Thing")
 const Container = require("./traits/container")
 
@@ -7,7 +9,14 @@ const Room = Thing.define({
   attributes: {
     exits: DEFAULT_EXITS
   },
-  traits: [Container]
+  traits: [Container],
+  actions: {
+    emit: function(sensoryEvent, context) {
+      _.each(this.contents, function(content) {
+        sensoryEvent.resolve(content, context)
+      })
+    }
+  }
 })
 
 module.exports = Room

--- a/src/commands/yawn.js
+++ b/src/commands/yawn.js
@@ -1,0 +1,24 @@
+const Command = require("../Command")
+const Guard = require("../Guard")
+const SensoryEvent = require("../SensoryEvent")
+
+const yawnEvent = SensoryEvent.create([
+  {
+    sense: "SIGHT",
+    magnitude: 100,
+    message: ({ actor }) => `${actor.name} yawns.`
+  }
+])
+
+const Yawn = Command.create({
+  name: "yawn",
+  guards: [
+    Guard.actorMustBeAlive,
+    Guard.actorMustBeAwake
+  ],
+  onSuccess: function(context) {
+    context.actor.room.emit(yawnEvent, context)
+  }
+})
+
+module.exports = Yawn

--- a/test/commands/yawn.js
+++ b/test/commands/yawn.js
@@ -1,0 +1,25 @@
+require("../support/helpers")
+
+const { expect } = require("chai")
+
+const YawnCommand = require("../../src/commands/yawn")
+
+const Character = require("../../src/Character")
+const Room = require("../../src/Room")
+
+describe("YawnCommand", function() {
+  context("when the room has an exit in the given direction", function() {
+    const room = Room.build({})
+    const actor = Character.build({ name: "Yoda", room })
+    const observer = Character.build({ name: "Obi-Wan",room })
+
+    room.add(actor)
+    room.add(observer)
+
+    it("appears to the observer that the actor is yawning", function() {
+      YawnCommand.issue(actor)
+
+      expect(actor).to.see("Yoda yawns.")
+    })
+  })
+})


### PR DESCRIPTION
This command is added as exploration. As it's the simplest form of command; an emote taking no arguments, and having no side effects.

The test revealed that there needs to be some clarification around sensory events, and how they resolve. Questions like: "should a room know how to emit events, or should events know how to emit in rooms", still need to be answered. Events also need to be able to tell when they are resolved in the actor where they originated, and adjust their message accordingly.