### PR TITLE
Make sure only one sense registers any single sensory event

### DIFF
--- a/src/SensoryEvent.js
+++ b/src/SensoryEvent.js
@@ -13,6 +13,8 @@ function create(impressions) {
 
         if(magnitude >= threshold) {
           receiver.perceive({ sense, message: message(context) })
+
+          return false
         }
       })
     }

--- a/test/SensoryEventTest.js
+++ b/test/SensoryEventTest.js
@@ -45,4 +45,20 @@ describe("SensoryEvent", function() {
       expect(receiver).to.see("Gandalf prancing around")
     })
   })
+
+  context("when the event is registered by multiple senses", function() {
+    const event = SensoryEvent.create([
+      { sense: "SIGHT",   magnitude: 60, message: ({ actor }) => `${actor.name} knocks on the door west of here` },
+      { sense: "HEARING", magnitude: 60, message: () => `someone knocks on a door` }
+    ])
+    const actor = Character.build({ name: "Frodo" })
+    const receiver = Character.build({ senses: { "SIGHT": { acuity: 40 }, "HEARING": { acuity: 40 } } })
+
+    it("forwards only the message to the prioritized sense", function() {
+      event.resolve(receiver, { actor })
+
+      expect(receiver).to.see("Frodo knocks on the door west of here")
+      expect(receiver).to.hear.nothing
+    })
+  })
 })

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -2,12 +2,12 @@ const _ = require("lodash")
 
 const { Assertion, util } = require("chai")
 
-addSenseAssertion("NONE", "notice", "noticed")
-addSenseAssertion("SIGHT", "see", "saw")
-addSenseAssertion("HEARING", "hear", "heard")
-addSenseAssertion("TOUCH", "feel", "felt")
-addSenseAssertion("SMELL", "smell", "smelled")
-addSenseAssertion("TASTE", "taste", "tasted")
+addSenseAssertion("NONE",    "notice", "noticed")
+addSenseAssertion("SIGHT",   "see",    "saw")
+addSenseAssertion("HEARING", "hear",   "heard")
+addSenseAssertion("TOUCH",   "feel",   "felt")
+addSenseAssertion("SMELL",   "smell",  "smelled")
+addSenseAssertion("TASTE",   "taste",  "tasted")
 
 function addSenseAssertion(sense, presentTenseVerb, pastTenseVerb) {
   Assertion.addChainableMethod(presentTenseVerb, function(message) {
@@ -22,7 +22,7 @@ function addSenseAssertion(sense, presentTenseVerb, pastTenseVerb) {
     )
   },
   function() {
-    util.flag(this, "sense", "SIGHT")
+    util.flag(this, "sense", sense)
     // TODO: extract inflection methods
     util.flag(this, "presentTenseVerb", presentTenseVerb)
     util.flag(this, "pastTenseVerb", pastTenseVerb)


### PR DESCRIPTION
Previously, the sensory event resolution would keep going even after one sense successfully perceived the event. This resulted in several impressions of the same event.

This change fixes that.