### PR TITLE
Update #assignAttributes to throw an error instead of a string

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/.nyc_output
+/coverage

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,9 @@
     "semi": [
       "error",
       "never"
+    ],
+    "no-throw-literal": [
+      "error"
     ]
   }
 }

--- a/src/Thing.js
+++ b/src/Thing.js
@@ -24,7 +24,7 @@ function assignAttributes(attributes, options) {
   if(_.isEmpty(unknownAttributes)) {
     return _.merge(_.cloneDeep(attributes), defaultAttributes, options)
   } else {
-    throw(`Unknown attributes: ${_.join(unknownAttributes, ", ")}`)
+    throw new Error(`Unknown attributes: ${_.join(unknownAttributes, ", ")}`)
   }
 }
 


### PR DESCRIPTION
This change enables the `no-throw-literal` option in ESLint, which enforces throwing instances of `Error`, and fixes an offence in `assignAttributes`.