### PR TITLE
Run ESLint as a pretest task

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ event.resolve(character)
 
 ## Testing
 
-You can easily run the test suite by invoking `npm test`.
+You can easily run the test suite by invoking `npm test`. (This will also run ESLint.)
 
 ### Custom Matchers
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "nyc --reporter=lcov mocha --recursive",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "pretest": "npm run lint"
   },
   "keywords": [
     "MUD"


### PR DESCRIPTION
This change makes `npm test` invoke the `lint` task before starting, so we don't forget to lint, and can have our CI fail on linting errors.